### PR TITLE
smooth: Make it work with any type of node

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Meaning: Add grass on top and change deeper nodes to stone.
 
 * `//smooth`
 
-Smooth terrain (`default:dirt` only) in the current selection.
+Smooth terrain in the current selection. When adding nodes, the type of the top-most node in the column is used.
 This uses an exponentially weighted moving average (EWMA) and should be ran 1 or 2 times to produce good results.
 
 * `//smoothbrush`

--- a/init.lua
+++ b/init.lua
@@ -247,11 +247,11 @@ local function smooth(pos1, pos2, deadzone)
 			elseif old_height < new_height then
 				-- need to add nodes
 				local y = old_height
-				local old_height_index = index_z + (offset.y + old_height - 1) * stride.y
+				local c_old_height = data[index_z + (offset.y + old_height - 1) * stride.y]
 				
 				while y <= new_height-1 do
 					local index = index_z + (offset.y + y) * stride.y
-					if data[index] == c_air then data[index] = data[old_height_index] end
+					if data[index] == c_air then data[index] = c_old_height end
 					
 					count = count + 1
 					y = y + 1

--- a/init.lua
+++ b/init.lua
@@ -133,7 +133,6 @@ local function smooth(pos1, pos2, deadzone)
 	local stride = {x=1, y=area.ystride, z=area.zstride}
 	local offset = vector.subtract(pos1, area.MinEdge)
 	local c_air = minetest.get_content_id("air")
-	local c_dirt = minetest.get_content_id("default:dirt")
 
 	-- read heightmap from data
 	local heightmap = {}
@@ -240,7 +239,7 @@ local function smooth(pos1, pos2, deadzone)
 				local y = old_height-1
 				while y >= new_height do
 					local index = index_z + (offset.y + y) * stride.y
-					if data[index] == c_dirt then data[index] = c_air end
+					if data[index] ~= c_air then data[index] = c_air end
 
 					count = count + 1
 					y = y - 1
@@ -248,10 +247,11 @@ local function smooth(pos1, pos2, deadzone)
 			elseif old_height < new_height then
 				-- need to add nodes
 				local y = old_height
+				local c_target = minetest.get_node(vector.new(index_x, old_height, index_z))
 				while y <= new_height-1 do
 					local index = index_z + (offset.y + y) * stride.y
-					if data[index] == c_air then data[index] = c_dirt end
-
+					if data[index] == c_air then data[index] = c_target end
+					
 					count = count + 1
 					y = y + 1
 				end

--- a/init.lua
+++ b/init.lua
@@ -247,7 +247,8 @@ local function smooth(pos1, pos2, deadzone)
 			elseif old_height < new_height then
 				-- need to add nodes
 				local y = old_height
-				local old_height_index = index_z + (offset.y + old_height) * stride.y
+				local old_height_index = index_z + (offset.y + old_height - 1) * stride.y
+				
 				while y <= new_height-1 do
 					local index = index_z + (offset.y + y) * stride.y
 					if data[index] == c_air then data[index] = data[old_height_index] end

--- a/init.lua
+++ b/init.lua
@@ -247,10 +247,10 @@ local function smooth(pos1, pos2, deadzone)
 			elseif old_height < new_height then
 				-- need to add nodes
 				local y = old_height
-				local c_target = minetest.get_node(vector.new(index_x, old_height, index_z))
+				local old_height_index = index_z + (offset.y + old_height) * stride.y
 				while y <= new_height-1 do
 					local index = index_z + (offset.y + y) * stride.y
-					if data[index] == c_air then data[index] = c_target end
+					if data[index] == c_air then data[index] = data[old_height_index] end
 					
 					count = count + 1
 					y = y + 1

--- a/init.lua
+++ b/init.lua
@@ -133,6 +133,7 @@ local function smooth(pos1, pos2, deadzone)
 	local stride = {x=1, y=area.ystride, z=area.zstride}
 	local offset = vector.subtract(pos1, area.MinEdge)
 	local c_air = minetest.get_content_id("air")
+	local c_dirt = minetest.get_content_id("default:dirt")
 
 	-- read heightmap from data
 	local heightmap = {}
@@ -247,7 +248,12 @@ local function smooth(pos1, pos2, deadzone)
 			elseif old_height < new_height then
 				-- need to add nodes
 				local y = old_height
-				local c_old_height = data[index_z + (offset.y + old_height - 1) * stride.y]
+				local c_old_height
+				if oldheight ~= 0 then
+					c_old_height = data[index_z + (offset.y + old_height - 1) * stride.y]
+				else
+					c_old_height = c_dirt
+				end
 				
 				while y <= new_height-1 do
 					local index = index_z + (offset.y + y) * stride.y

--- a/init.lua
+++ b/init.lua
@@ -299,7 +299,7 @@ minetest.register_chatcommand("/populate", {
 
 minetest.register_chatcommand("/smooth", {
 	params = "",
-	description = "Smooth terrain (dirt) in current WorldEdit region",
+	description = "Smooth terrain in current WorldEdit region",
 	privs = {worldedit=true},
 	func = function(name, param)
 		local pos1, pos2 = worldedit.pos1[name], worldedit.pos2[name]


### PR DESCRIPTION
Untested! O.o

I saw this repo when looking for a smooth command in Minetest, and also saw that the smooth command only worked on dirt. This PR fixes that. It now does this:

 - If a column is too high, it selectively removes things by testing inequality with air, instead of equality with dirt.
 - If a column is too low, then the block used to top the column off is decided by the topmost block of the old height.
